### PR TITLE
Feature: Timer - killed surviving mutants

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -22,7 +22,7 @@ jobs:
             -  java: 8
             -  java: 17
                additional-maven-args: >
-                  -Pcoveralls sonar:sonar  
+                  -Pcoveralls,mutation-testing sonar:sonar  
                   -DrepoToken=$COVERALLS_REPO_TOKEN
                   -DpullRequest=${{ github.event.pull_request.number }}
                   -Dsonar.projectKey=ciodar_tdd-scoreboard

--- a/com.ciodar.scoreboard/src/main/java/com/ciodar/scoreboard/StopWatch.java
+++ b/com.ciodar.scoreboard/src/main/java/com/ciodar/scoreboard/StopWatch.java
@@ -20,7 +20,7 @@ public class StopWatch {
 	public long tick() {
 		long elapsed = clock.currentTimeMillis() - start;
 		if (elapsed < 0)
-			throw new RuntimeException("Unexpected negative elapsed time");
+			throw new IllegalStateException("Unexpected negative elapsed time");
 		if (initialTime - elapsed > 0)
 			return initialTime - elapsed;
 		else

--- a/com.ciodar.scoreboard/src/main/java/com/ciodar/scoreboard/StopWatch.java
+++ b/com.ciodar.scoreboard/src/main/java/com/ciodar/scoreboard/StopWatch.java
@@ -1,20 +1,35 @@
 package com.ciodar.scoreboard;
 
 public class StopWatch {
-	
+
 	private Clock clock;
 	private long start;
 	private long initialTime;
+	private boolean running;
 
 	public StopWatch(Clock clock, long initialTime) {
 		this.clock = clock;
 		this.initialTime = initialTime;
+	}
+
+	public void start() {
+		this.running = true;
 		this.start = clock.currentTimeMillis();
 	}
 
 	public long tick() {
 		long elapsed = clock.currentTimeMillis() - start;
-		return (initialTime - elapsed > 0) ? initialTime - elapsed: 0;
+		if (elapsed < 0)
+			throw new RuntimeException("Unexpected negative elapsed time");
+		if (initialTime - elapsed > 0)
+			return initialTime - elapsed;
+		else
+			this.running = false;
+		return 0;
+	}
+
+	public boolean isRunning() {
+		return running;
 	}
 
 }

--- a/com.ciodar.scoreboard/src/test/java/com/ciodar/scoreboard/TimerTest.java
+++ b/com.ciodar.scoreboard/src/test/java/com/ciodar/scoreboard/TimerTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.*;
 
 public class TimerTest {
 	private static final long REMAINING = 10000L;
+	private static final long START_TIME = 1000L;
 	Clock stubClock;
 	StopWatch stopWatch;
 	
@@ -15,30 +16,46 @@ public class TimerTest {
 	@Before
 	public void setup() {
 		stubClock = mock(Clock.class);
-		when(stubClock.currentTimeMillis()).thenReturn(0L);
+		when(stubClock.currentTimeMillis()).thenReturn(START_TIME);
 		stopWatch = new StopWatch(stubClock, REMAINING);
+		stopWatch.start();
 	}
 	
 	@Test
 	public void testStartStopwatchZeroSecondPassedShouldReturnRemaining() {
 		assertEquals(stopWatch.tick(),REMAINING);
+		assertEquals(true, stopWatch.isRunning());
 	}
 	
 	@Test
 	public void testStartStopwatchOneSecondPassedShouldReturnRemaining() {
-		when(stubClock.currentTimeMillis()).thenReturn(1000L);
-		assertEquals(stopWatch.tick(), REMAINING - 1000L);
+		long time_passed = 1000L;
+		when(stubClock.currentTimeMillis()).thenReturn(START_TIME + time_passed);
+		assertEquals(stopWatch.tick(), REMAINING - time_passed);
+		assertEquals(true, stopWatch.isRunning());
 	}
 	
 	@Test
 	public void testStartStopwatchTenSecondPassedShouldReturnZero() {
-		when(stubClock.currentTimeMillis()).thenReturn(10000L);
+		long time_passed = 10000L;
+		when(stubClock.currentTimeMillis()).thenReturn(START_TIME + time_passed);
 		assertEquals(stopWatch.tick(), 0);
+		assertEquals(false, stopWatch.isRunning());
 	}
 	
 	@Test 
 	public void testStartStopWatchElevenSecondPassesShouldReturnZero() {
-		when(stubClock.currentTimeMillis()).thenReturn(11000L);
+		long time_passed = 11000L;
+		when(stubClock.currentTimeMillis()).thenReturn(START_TIME + time_passed);
 		assertEquals(stopWatch.tick(), 0);
+		assertEquals(false, stopWatch.isRunning());
+	}
+	
+	@Test(expected = RuntimeException.class)
+	public void testTimeRunningBackwardsShouldThrow() {
+		long time_passed = -1000L;
+		when(stubClock.currentTimeMillis()).thenReturn(START_TIME + time_passed);
+		stopWatch.tick();
+		fail();
 	}
 }


### PR DESCRIPTION
Activated mutation testing in CI and killed surviving mutants

- Added boolean variable to indicate whether the timer is running or time is finished
- Throws exception for negative elapsed time (could happen if system time is changed during execution?)
- If elapsed time is greater than set time, timer should return zero
- Moved timer start out of the constructor